### PR TITLE
Fix #mrakitin/SRW#28: basic-test.sh runs Example10 with timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ fftw_file = $(fftw_version).tar.gz
 log_fftw = /dev/null
 examples_dir = $(env_dir)/work/srw_python
 example10_data_dir = $(examples_dir)/data_example_10
-test_timeout = 20
 
 nofftw: core pylib
 
@@ -52,40 +51,7 @@ pylib:
 	cd $(py_dir); make python
 
 test:
-	remove_tmp_dir=0; \
-	if [ ! -d "$(example10_data_dir)" ]; then \
-	    mkdir $(example10_data_dir); \
-	    remove_tmp_dir=1; \
-	fi; \
-	cd $(examples_dir); \
-	sh -c '(sleep $(test_timeout); kill "$$$$" > /dev/null 2>&1) & exec python SRWLIB_Example10.py'; \
-	code=$$?; \
-	RED=1; \
-	GREEN=2; \
-	if [ $$code -eq 0 ]; then \
-	    status='PASSED'; \
-	    color=$${GREEN}; \
-	    message=''; \
-	elif [ $$code -eq 143 ]; then \
-	    status='PASSED'; \
-	    color=$${GREEN}; \
-	    message=' (timeouted, expected)'; \
-	else \
-	    status='FAILED'; \
-	    color=$${RED}; \
-	    message=''; \
-	fi; \
-	printf '\n\n\t%s' 'Test '; \
-	tput setaf $${color}; \
-	tput bold; \
-	printf '%s' "$${status}"; \
-	tput sgr0; \
-	printf '%s\n\n' ". Code=$${code}$${message}"; \
-	rm -f $(example10_data_dir)/{ex10_res_int_se.dat,ex10_res_int_prop_se.dat,ex10_res_int_prop_me.dat}; \
-	if [ $$remove_tmp_dir -eq 1 ]; then \
-	    cd $(root_dir); \
-	    rm -rf $(example10_data_dir); \
-	fi;
+	bash $(examples_dir)/basic-test.sh
 
 clean:
 	rm -f $(ext_dir)/libfftw.a $(gcc_dir)/libsrw.a $(gcc_dir)/srwlpy*.so; \

--- a/env/work/srw_python/basic-test.sh
+++ b/env/work/srw_python/basic-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Run an example (SRWLIB_Example10.py) to verify build
+#
+set -e
+
+# Overridable parameters, e.g. timeout_s=2 bash basic-test.sh
+: ${timeout_s:=20}
+: ${ex_n:=10}
+data_d=data_example_$ex_n
+example_py=SRWLIB_Example$ex_n.py
+out=$data_d/$example_py.log
+
+# No color if stdout is not a tty
+if [[ ! -t 1 ]]; then
+    tput() { return; }
+fi
+
+# cleanup: kill hanging process, remove temporary directory, output files
+pid=
+to_remove=()
+cleanup() {
+    set +e
+    if [[ -n $pid ]]; then
+        kill -9 "$pid" && wait "$pid" >& /dev/null
+        pid=
+    fi
+    local f
+    for f in "${to_remove[@]}"; do
+        rm -rf "$f"
+    done
+    to_remove=
+}
+trap cleanup EXIT ERR
+
+# Start in examples directory
+cd "$(dirname "$0")"
+if [[ ! -d $data_d ]]; then
+    mkdir -p "$data_d"
+    to_remove+=( $data_d )
+fi
+
+# Run example with timeout
+python "$example_py" >& "$out" &
+pid=$!
+status='PASS'
+msg=' (timeout)'
+color=2 # green
+i=0
+while (( $i < $timeout_s )); do
+    sleep 1
+    i=$((i + 1))
+    if kill -0 "$pid" >& /dev/null; then
+        continue
+    fi
+    code=$(wait "$pid" >&/dev/null || echo $?)
+    pid=
+    if (( $code )); then
+        # Let the user know what went wrong
+        tail "$out"
+        status=FAIL
+        msg=" (code=$code)"
+        color=1 # red
+        exit=1
+    else
+        status=PASS
+        msg=
+    fi
+    break
+done
+echo "$example_py: $(tput setaf $color)$(tput bold)$status$(tput sgr0)$msg"
+#TODO(robnagler) this should be generalized
+to_remove+=( $data_d/ex${ex_n}_res_{int_se,prop_se,prop_me}.dat )
+exit $code


### PR DESCRIPTION
This works on Mac and Fedora. Should run anywhere with a reasonable
bash. It solves the tty problem, and a bit more. :)
I can explain the design choices if you like, but I thought
it would be good to have a "solid" test in place